### PR TITLE
Add support to cross-compile for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Furthermore, files may exist but always return an error code for some zones or c
 ## Building
 
 ### Compiling
+(In order to cross-compile for another architecture, please see section
+Cross-compiling below)
 
 This project uses CMake.
 
@@ -132,6 +134,20 @@ To create a shared object library as a release build, specify for cmake:
 
 ``` sh
 cmake .. -DBUILD_SHARED_LIBS=On -DCMAKE_BUILD_TYPE=Release
+```
+
+### Cross-Compiling
+
+This project uses CMake. A sample configuration to cross-compile for
+aarch64 on a x86-host is provided in aarch64.cmake.
+
+To build, run:
+
+``` sh
+mkdir _build
+cd _build
+cmake -DCMAKE_TOOLCHAIN_FILE=../aarch64.cmake ..
+make
 ```
 
 ### Installing

--- a/aarch64.cmake
+++ b/aarch64.cmake
@@ -1,0 +1,17 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+#this one not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+
+# specify the cross compiler
+SET(CMAKE_C_COMPILER   /bin/aarch64-linux-gnu-gcc)
+
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH /usr/aarch64-linux-gnu)
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+# end of the file


### PR DESCRIPTION
Provide a configuration file and update README.md with instructions to
cross-compile for aarch64 on a x86-host.